### PR TITLE
Configurar headers en vercel para imágenes svg

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,7 @@
+# Permitir servir SVG
+AddType image/svg+xml svg svgz
+AddEncoding gzip svgz
+
+<FilesMatch "\.svg$">
+  Require all granted
+</FilesMatch>


### PR DESCRIPTION
## Issues relacionados

Por confirmar

## Descripción del problema

No están apareciendo las imágenes svg en producción debido a un error 403

<img width="1919" height="658" alt="image" src="https://github.com/user-attachments/assets/c197f660-8a1a-4b44-8b50-2283b6ebbdd4" />

## Qué se hizo para resolver problema

Se agregó una configuración de headers en vercel para este tipo de imágenes

## Cómo probar

No hay manera de probar en local