### PR TITLE
Automatizar año de derechos de autor y añadir despliegue programado anual

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 5 1 1 *'
 
 permissions:
   contents: read

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,6 +2,7 @@
 import { Image } from 'astro:assets';
 import LinkedinLogoIcon from "@icons/linkedin.svg";
 import FacebookLogoIcon from "@icons/facebook.svg";
+const currentYear = new Date().getFullYear();
 ---
 
 <footer class="bg-dark-color w-full md:w-[90%] md:max-w-[1200px] text-white-color px-5 pt-[50px] pb-[30px] md:p-16 mx-auto rounded-none md:rounded-t-[45px]">
@@ -65,7 +66,7 @@ import FacebookLogoIcon from "@icons/facebook.svg";
     </div>
     <div class="bg-white-color w-full h-px"></div>
     <div class="text-center text-base md:text-lg md:text-start flex flex-col md:flex-row items-center gap-4 md:gap-10">
-      <span>© 2025 Keracode. Todos los derechos reservados.</span>
+      <span>© {currentYear} Keracode. Todos los derechos reservados.</span>
       <a href="/private-policies" arial-label="Mira nuestras políticas privadas aquí"><p class="md:underline hover:no-underline">Políticas privadas</p></a>
     </div>
   </div>


### PR DESCRIPTION
## 📝 Descripción
Este PR automatiza la actualización del año de derechos de autor en el footer y asegura que el sitio estático se reconstruya automáticamente al inicio de cada año sin necesidad de intervención manual.

## 🛠️ Cambios realizados
- **Footer.astro**: Se cambió el año estático por `new Date().getFullYear()`.
- **deploy.yml**: Se añadió un disparador `schedule` con la expresión cron `0 5 1 1 *` para ejecutar el despliegue automático en Año Nuevo (medianoche en huso horario de Perú).