### PR TITLE
Corregir error de sintaxis de arial-label por aria-label en links

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,17 +11,17 @@ import FacebookLogoIcon from "@icons/facebook.svg";
       <nav>
         <ul class="flex flex-col md:flex-row items-center gap-4 md:gap-10">
           <li>
-            <a href="/#services" class="cursor-pointer text-base md:text-lg md:underline hover:no-underline" arial-label="Mira nuestros servicios aquí">
+            <a href="/#services" class="cursor-pointer text-base md:text-lg md:underline hover:no-underline" aria-label="Mira nuestros servicios aquí">
               <p>Servicios</p>
             </a>
           </li>
           <li>
-            <a href="/#products" class="cursor-pointer text-base md:text-lg md:underline hover:no-underline" arial-label="Mira nuestros productos aquí">
+            <a href="/#products" class="cursor-pointer text-base md:text-lg md:underline hover:no-underline" aria-label="Mira nuestros productos aquí">
               <p>Productos</p>
             </a>
           </li>
           <li>
-            <a href="/#about" class="cursor-pointer text-base md:text-lg md:underline hover:no-underline" arial-label="Mira más acerca de nosotros aquí">
+            <a href="/#about" class="cursor-pointer text-base md:text-lg md:underline hover:no-underline" aria-label="Mira más acerca de nosotros aquí">
               <p>Nosotros</p>
             </a>
           </li>
@@ -29,12 +29,12 @@ import FacebookLogoIcon from "@icons/facebook.svg";
       </nav>
       <ul class="hidden lg:flex items-center gap-5">
         <li class="cursor-pointer">
-          <a href="https://www.linkedin.com/company/keracode-peru" target="_blank" rel="noopener noreferrer" arial-label="Mira nuestro Linkedin aquí">
+          <a href="https://www.linkedin.com/company/keracode-peru" target="_blank" rel="noopener noreferrer" aria-label="Mira nuestro Linkedin aquí">
             <Image src={LinkedinLogoIcon} alt="Linkedin de Keracode" width="30" height="30" />
           </a>
         </li>
         <li class="cursor-pointer">
-          <a href="https://www.facebook.com/keracodeperu" target="_blank" rel="noopener noreferrer" arial-label="Mira nuestro Facebook aquí">
+          <a href="https://www.facebook.com/keracodeperu" target="_blank" rel="noopener noreferrer" aria-label="Mira nuestro Facebook aquí">
             <Image src={FacebookLogoIcon} alt="Facebook de Keracode" width="30" height="30" />
           </a>
         </li>
@@ -52,12 +52,12 @@ import FacebookLogoIcon from "@icons/facebook.svg";
     <div class="flex items-center justify-center lg:hidden">
       <ul class="flex items-center gap-5">
         <li class="cursor-pointer">
-          <a href="https://www.linkedin.com/company/keracode-peru" target="_blank" rel="noopener noreferrer" arial-label="Mira nuestro Linkedin aquí">
+          <a href="https://www.linkedin.com/company/keracode-peru" target="_blank" rel="noopener noreferrer" aria-label="Mira nuestro Linkedin aquí">
             <Image src={LinkedinLogoIcon} alt="Linkedin de Keracode" width="30" height="30" />
           </a>
         </li>
         <li class="cursor-pointer">
-          <a href="https://www.facebook.com/keracodeperu" target="_blank" rel="noopener noreferrer" arial-label="Mira nuestro Facebook aquí">
+          <a href="https://www.facebook.com/keracodeperu" target="_blank" rel="noopener noreferrer" aria-label="Mira nuestro Facebook aquí">
             <Image src={FacebookLogoIcon} alt="Facebook de Keracode" width="30" height="30" />
           </a>
         </li>
@@ -66,7 +66,7 @@ import FacebookLogoIcon from "@icons/facebook.svg";
     <div class="bg-white-color w-full h-px"></div>
     <div class="text-center text-base md:text-lg md:text-start flex flex-col md:flex-row items-center gap-4 md:gap-10">
       <span>© 2025 Keracode. Todos los derechos reservados.</span>
-      <a href="/private-policies" arial-label="Mira nuestras políticas privadas aquí"><p class="md:underline hover:no-underline">Políticas privadas</p></a>
+      <a href="/private-policies" aria-label="Mira nuestras políticas privadas aquí"><p class="md:underline hover:no-underline">Políticas privadas</p></a>
     </div>
   </div>
 </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,7 +17,7 @@ const Header = () => {
               <a
                 href="/#services"
                 className="cursor-pointer hover:underline"
-                arial-label="Mira nuestros servicios aquí"
+                aria-label="Mira nuestros servicios aquí"
               >
                 <span className="cursor-pointer">Servicios</span>
               </a>
@@ -26,7 +26,7 @@ const Header = () => {
               <a
                 href="/#products"
                 className="cursor-pointer hover:underline"
-                arial-label="Mira nuestros productos aquí"
+                aria-label="Mira nuestros productos aquí"
               >
                 <span className="cursor-pointer">Productos</span>
               </a>
@@ -35,13 +35,13 @@ const Header = () => {
               <a
                 href="/#about"
                 className="cursor-pointer hover:underline"
-                arial-label="Mira más acerca de nosotros aquí"
+                aria-label="Mira más acerca de nosotros aquí"
               >
                 <span className="cursor-pointer">Nosotros</span>
               </a>
             </li>
             <li>
-              <a href="/#contact" arial-label="Contáctanos aquí">
+              <a href="/#contact" aria-label="Contáctanos aquí">
                 <Button text="Contáctanos" variant="outline" />
               </a>
             </li>
@@ -72,7 +72,7 @@ const Header = () => {
               <a
                 href="/#services"
                 className="h-full w-full flex items-center justify-center"
-                arial-label="Mira nuestros servicios aquí"
+                aria-label="Mira nuestros servicios aquí"
               >
                 <span className="cursor-pointer">Servicios</span>
               </a>
@@ -81,7 +81,7 @@ const Header = () => {
               <a
                 href="/#products"
                 className="h-full w-full flex items-center justify-center"
-                arial-label="Mira nuestros productos aquí"
+                aria-label="Mira nuestros productos aquí"
               >
                 <span className="cursor-pointer">Productos</span>
               </a>
@@ -90,7 +90,7 @@ const Header = () => {
               <a
                 href="/#about"
                 className="h-full w-full flex items-center justify-center"
-                arial-label="Mira más acerca de nosotros aquí"
+                aria-label="Mira más acerca de nosotros aquí"
               >
                 <span className="cursor-pointer">Nosotros</span>
               </a>
@@ -99,7 +99,7 @@ const Header = () => {
               <a
                 href="/#contact"
                 className="h-full w-full flex items-center justify-center"
-                arial-label="Contáctanos aquí"
+                aria-label="Contáctanos aquí"
               >
                 <span className="cursor-pointer">Contáctanos</span>
               </a>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -10,7 +10,7 @@ import IllustrationIcon from "@icons/illustration.svg";
       <h1 class="text-5xl md:text-6xl font-medium">Impulsamos tu negocio con tecnología</h1>
       <Image src={IllustrationIcon} class="block md:hidden" alt="Desarrollamos soluciones digitales a medida para pequeñas y medianas empresas. Desde sitios web y aplicaciones hasta soporte técnico, te ayudamos a transformar tu negocio con tecnología innovadora y eficiente." width="600" height="310" />
       <p class="text-base md:text-xl">Desarrollamos soluciones digitales a medida para pequeñas y medianas empresas. Desde sitios web y aplicaciones hasta soporte técnico, te ayudamos a transformar tu negocio con tecnología innovadora y eficiente.</p>
-      <a href="/#contact" class="hidden md:block" arial-label="Agenda una reunión">
+      <a href="/#contact" class="hidden md:block" aria-label="Agenda una reunión">
         <Button client:load text="Agenda una reunión" />
       </a>
     </div>
@@ -19,7 +19,7 @@ import IllustrationIcon from "@icons/illustration.svg";
       <Image src={IllustrationIcon} alt="Impulsamos tu negocio con tecnología" width="600" height="500" />
     </div>
 
-    <a href="/#contact" class="block md:hidden" arial-label="Agenda una reunión">
+    <a href="/#contact" class="block md:hidden" aria-label="Agenda una reunión">
       <Button client:load text="Agenda una reunión" hasFullWidth />
     </a>
   </div>

--- a/src/components/ProductCard.astro
+++ b/src/components/ProductCard.astro
@@ -54,12 +54,12 @@ const cardTextColor = {
     <div class="w-full md:w-1/2 flex flex-col justify-between gap-8">
       <h3 class=`${cardTitleColor[color]} w-fit text-[26px] md:text-3xl font-medium px-2 py-1 rounded-lg whitespace-nowrap`>{title}</h3>
       <div class="flex items-end md:items-center justify-between md:justify-start gap-4">
-        <a href={url} target="_blank" rel="noopener noreferrer" arial-label="Ver más información del producto">
+        <a href={url} target="_blank" rel="noopener noreferrer" aria-label="Ver más información del producto">
           <span class=`${cardIconColor[color]} w-10 h-10 flex items-center justify-center rounded-full`>
             <Image src={cardArrowColor[color]} alt="Ver más información del producto" width="20" height="20" />
           </span>
         </a>
-        <a href={url} target="_blank" rel="noopener noreferrer" arial-label="Ver más información del producto">
+        <a href={url} target="_blank" rel="noopener noreferrer" aria-label="Ver más información del producto">
           <p class=`${cardTextColor[color]} hidden md:block whitespace-nowrap cursor-pointer hover:underline`>Ver más</p>
         </a>
         <Image src={image} class="block md:hidden" alt={description} width="140" height="120" />

--- a/src/components/TeamCard.astro
+++ b/src/components/TeamCard.astro
@@ -22,7 +22,7 @@ const { title, role, description, image, url }: ITeamCardProps = Astro.props as 
         <p class="text-lg">{role}</p>
       </div>
       <div class="h-full flex-1">
-        <a href={url} target="_blank" rel="noopener noreferrer" arial-label=`Ver el perfil de trabajo de ${title}` class="w-[34px] min-w-[34px] h-[34px] min-h-[34px] flex">
+        <a href={url} target="_blank" rel="noopener noreferrer" aria-label=`Ver el perfil de trabajo de ${title}` class="w-[34px] min-w-[34px] h-[34px] min-h-[34px] flex">
           <Image src={LinkedinCardIcon} alt={description} width="34" height="34" class="cursor-pointer" />
         </a>
       </div>


### PR DESCRIPTION
## 📝 Descripción
Este PR corrige un error ortográfico en los atributos de accesibilidad de los componentes. Se reemplaza la sintaxis incorrecta `arial-label` por el estándar nativo de la web `aria-label`.

## 🛠️ Cambios realizados
Se actualizaron todos los enlaces de navegación interna y los iconos de redes sociales para que utilicen `aria-label` correctamente, garantizando que los lectores de pantalla puedan interpretar el contexto de los enlaces.